### PR TITLE
Fixed bootstrapper to alter default retention policy

### DIFF
--- a/src/bootstrapper/main.go
+++ b/src/bootstrapper/main.go
@@ -39,7 +39,7 @@ func main() {
 		panic(fmt.Sprintf("Error creating DB '%s': %s", *databaseName, err))
 	}
 
-	retentionCommand := fmt.Sprintf("create RETENTION POLICY \"default\" ON %s DURATION %s REPLICATION %s DEFAULT", *databaseName, *retention, *replication)
+	retentionCommand := fmt.Sprintf("ALTER RETENTION POLICY \"default\" ON %s DURATION %s REPLICATION %s DEFAULT", *databaseName, *retention, *replication)
 	_, err = dbClient.Query(client.Query{Command: retentionCommand})
 	if err != nil {
 		panic(fmt.Sprintf("Error creating default retention policy: %s", err))


### PR DESCRIPTION
Updated bootstrapper source to ALTER policy as default as a retention policy already exists in influxdb with a retention of 0 (infinite).  Issuing a create does not change it/nor triggers an error in the logs.
